### PR TITLE
 [BUG FIX] Corrected concatenation order

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -79,6 +79,8 @@ for video_name, url_for_manifest in videos.items():
         # concatenating all downloaded files
         video_tokens = os.listdir(f'./videos/')
         video_tokens = [video for video in video_tokens if video]
+        video_tokens = sorted(video_tokens, key = lambda x: str(x))
+
         with open('files.txt', 'w') as output_file:
             output_file.write("\n".join([f"file 'videos/{token}'" for token in video_tokens]))
 


### PR DESCRIPTION
Once i tried the script the videos output were incoerent (basically random merged) idk if it's a problem with Ubuntu :((
With this fix it works on Ubuntu and doesn't have any impact on Windows